### PR TITLE
Option to disable autostart of compile when page loads

### DIFF
--- a/DotVVM.Diagnostics.StatusPage/Status.dothtml
+++ b/DotVVM.Diagnostics.StatusPage/Status.dothtml
@@ -73,7 +73,7 @@
         <h1>
             Compilation Status Page
         </h1>
-        <dot:Button ID="compile-all-button" Click="{command: CompileAll()}" Text="Compile All" class="btn btn-primary float-right"></dot:Button>
+        <dot:Button ID="compile-all-button" Click="{command: CompileAll()}" Text="Compile All" class="btn btn-primary float-right" class-js-compile-auto="{value: CompileAfterLoad}"></dot:Button>
         <dot:UpdateProgress class="update-box">
             <p class="compiling-update-progress">Compiling<span>.</span><span>.</span><span>.</span></p>
         </dot:UpdateProgress>
@@ -219,7 +219,10 @@
 
     <dot:InlineScript>
         dotvvm.events.init.subscribe(function () {
-            document.getElementById('compile-all-button').click();
+            var button = document.getElementById('compile-all-button');
+            if (button.classList.contains("js-compile-auto")) {
+                button.click();
+            }
         });
     </dot:InlineScript>
 

--- a/DotVVM.Diagnostics.StatusPage/StatusPageOptions.cs
+++ b/DotVVM.Diagnostics.StatusPage/StatusPageOptions.cs
@@ -10,6 +10,8 @@ namespace DotVVM.Diagnostics.StatusPage
 
         public string Url { get; set; } = "_diagnostics/status";
 
+        public bool CompileAfterPageLoads { get; set; } = true;
+
         public Func<IDotvvmRequestContext, Task<bool>> Authorize { get; set; }
             = context => Task.FromResult(context.HttpContext.Request.Url.IsLoopback);
 

--- a/DotVVM.Diagnostics.StatusPage/StatusViewModel.cs
+++ b/DotVVM.Diagnostics.StatusPage/StatusViewModel.cs
@@ -18,6 +18,7 @@ namespace DotVVM.Diagnostics.StatusPage
 
         public List<DotHtmlFileInfo> Controls { get; set; }
         public string ApplicationPath { get; set; }
+        public bool CompileAfterLoad { get; set; }
 
         public StatusViewModel(StatusPageOptions statusPageOptions)
         {
@@ -40,6 +41,7 @@ namespace DotVVM.Diagnostics.StatusPage
                 MasterPages = new List<DotHtmlFileInfo>();
             }
             ApplicationPath = Context.Configuration.ApplicationPhysicalPath;
+            CompileAfterLoad = _statusPageOptions.CompileAfterPageLoads;
             await base.Init();
         }
 


### PR DESCRIPTION
Added possibility to disable auto-compile when page loads (which is quite helpful for debugging when something does not work).